### PR TITLE
Fix infinite re-renders and refactor useToken hook 

### DIFF
--- a/src/Components/common/Header.js
+++ b/src/Components/common/Header.js
@@ -13,7 +13,7 @@ function Header() {
         <div>
           <nav className="navbar navbar-expand-lg navbar-light bg-secondary">
             <span className="navbar-brand" href="#" style={{paddingLeft: `2vw`, color: 'white'}}>Articles</span>
-             <NavbarToggler onClick={setisOpen(true)} style={{color: "white"}}><span className="navbar-toggler-icon"></span></NavbarToggler>
+             <NavbarToggler onClick={()=>setisOpen(true)} style={{color: "white"}}><span className="navbar-toggler-icon"></span></NavbarToggler>
              <Collapse isOpen={isOpen} navbar>
               <ul className="navbar-nav">
                 <li className="nav-item active">

--- a/src/Components/common/useToken.js
+++ b/src/Components/common/useToken.js
@@ -1,24 +1,25 @@
-import {useState} from 'react';
+import { useState, useEffect } from "react";
 
-export default function useToken(){
+const getToken = (initialValue) => {
+  const tokenString = JSON.parse(localStorage.getItem("token"));
+  if (tokenString) return tokenString;
+  if (initialValue instanceof Function) return initialValue();
+  console.log("reached getToken()");
+  return initialValue;
+};
 
-    const getToken=()=>{
-        const tokenString = sessionStorage.getItem('token');
-        const userToken = tokenString;
-        return userToken;
-   }
-   
-    const [token,setToken] = useState(getToken());
+const useToken = (initialValue) => {
+  const [token, setToken] = useState(() => {
+    return getToken(initialValue);
+  });
 
-    const saveToken = userToken =>{
-        sessionStorage.setItem('token', userToken);
-        console.log(userToken);
-        setToken(userToken);
-   };
+  useEffect(() => {
+    console.log("token changed");
+    console.log("TOKEN: ", token);
+    localStorage.setItem("token", JSON.stringify(token));
+  }, [token]);
 
-   return {
-       setToken: saveToken,
-       token
-   }
-   
-}
+  return [token, setToken];
+};
+
+export default useToken;


### PR DESCRIPTION
Changes proposed in this pull request:

In [Header.js](https://github.com/Himrajgogoi/jec_blog_web/blob/main/src/Components/common/Header.js)
-  setisOpen is called by using an anonymous function in [Header.js](https://github.com/Himrajgogoi/jec_blog_web/blob/main/src/Components/common/Header.js)
   (fixes infinite re-renders)

In [useToken.js](https://github.com/Himrajgogoi/jec_blog_web/blob/main/src/Components/common/useToken.js)
-  setisOpen is called using an anonymous function in [Header.js]
- useToken now has the same syntax for usage as useState
- token is stored in local storage instead of session storage for persistence
- useEffect is used for writing token to local storage instead of separate function